### PR TITLE
multiple-packages sample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+
+go:
+  - 1.7
+
+install:
+  - go get golang.org/x/tools/cmd/cover
+  # - go get github.com/mattn/goveralls
+  - git clone -b multiple-packages https://github.com/haya14busa/goveralls $GOPATH/src/github.com/haya14busa/goveralls
+  - cd $GOPATH/src/github.com/haya14busa/goveralls
+  - go get -d -v -t ./...
+  - go install
+  - cd -
+
+script:
+  - goveralls -service=travis-ci


### PR DESCRIPTION
coverage should be 100% but it's not because of lack of `-coverpkg` option.
